### PR TITLE
use python3 in shebang

### DIFF
--- a/linux2bsd.py
+++ b/linux2bsd.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import fnmatch
 import os
 import queue


### PR DESCRIPTION
in my debian stable system `./linux2bsd` runs python2, with this change, runs it with python3